### PR TITLE
On OS X, use two-level namespace and dynamic lookup of undefined symbols

### DIFF
--- a/unix/configure
+++ b/unix/configure
@@ -3651,7 +3651,7 @@ build_cpu=`uname -p`
 case $build_os in
   Darwin*)
     SHLIB_SUFFIX=".dylib"
-    SHLIB_LD="${CXX} -dynamiclib -flat_namespace -undefined suppress"
+    SHLIB_LD="${CXX} -dynamiclib -undefined dynamic_lookup"
     STRIP_FLAGS=-S
     ;;
   HP-UX*)

--- a/unix/configure.in
+++ b/unix/configure.in
@@ -155,7 +155,7 @@ build_cpu=`uname -p`
 case $build_os in
   Darwin*)
     SHLIB_SUFFIX=".dylib"
-    SHLIB_LD="${CXX} -dynamiclib -flat_namespace -undefined suppress"
+    SHLIB_LD="${CXX} -dynamiclib -undefined dynamic_lookup"
     STRIP_FLAGS=-S
     ;;
   HP-UX*)


### PR DESCRIPTION
This PR changes configure.in and configure to use the two-devel namespace and dynamic lookup of undefined symbols for building Mac OS X dynamic libraries. This is what modern autotools projects automatically select when building on Mac OS X 10.3 and later.

The flat namespace and suppression of undefined symbols was used on Mac OS X 10.2 and earlier, but we can probably ignore those systems by now, since Mac OS X 10.3 was released in 2003.