### PR TITLE
Update URLs in README

### DIFF
--- a/README
+++ b/README
@@ -34,11 +34,11 @@ DOCUMENTATION - All documentation uses HTML.  The main page is "Metakit.html",
     The C++ API Reference is extracted from the source code using Doxygen.
 
 WEBSITE URLS - The main pages on the world wide web, for news and downloads:
-    Homepage:       http://www.equi4.com/metakit.html
-    Python news:    http://www.equi4.com/metakit/python.html
-    Tcl/Tk news:    http://www.equi4.com/metakit/tcl.html
-    License info:   http://www.equi4.com/metakit/license.html
-    Contact info:   http://www.equi4.com/about/contact.html
+    Homepage:       http://equi4.com/metakit/
+    Python news:    http://equi4.com/metakit/python.html
+    Tcl/Tk news:    http://equi4.com/metakit/tcl.html
+    License info:   http://equi4.com/metakit/license.html
+    Contact info:   http://equi4.com/about/contact.html
 
 ACKNOWLEDGEMENTS - Thanks to everyone who has helped shape and extend Metakit,
     including Kyrill Denisenko, Mark Roseman, Gordon McMillan, Matt Newman,


### PR DESCRIPTION
This PR updates the project URLs in the README.

I changed the hostname from www.equi4.com to equi4.com, because that appears to be the server's new canonical hostname and it issues redirects from the old name to the new name. Making this change will result in lower server load because the server doesn't have to issue the redirect, and faster response times for users because they don't have to wait for the redirect.

The project's previously-advertized homepage URL, http://www.equi4.com/metakit.html, now returns 404 not found, so I changed it what appears to be the current homepage URL, http://equi4.com/metakit/. The old URL still appears in the header of all the source files and should be changed there as well. If possible, the server's configuration should be altered so that requests for the old homepage URL redirect to the new one.